### PR TITLE
Use single export ext function instead of exporting `interactRule` facet

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,24 +16,24 @@ new EditorView({
   state: EditorState.create({
     doc: 'const num = 123',
     extensions: [
-      // the plugin controlling the behavior (will do nothing without any interactRule)
-      interact,
-      // a rule for a number dragger
-      interactRule.of({
-        // the regexp matching the value
-        regexp: /-?\b\d+\.?\d*\b/g,
-        // set cursor to "ew-resize" on hover
-        cursor: "ew-resize",
-        // change number value based on mouse X movement on drag
-        onDrag: (text, setText, e) => {
-          const newVal = Number(text) + e.movementX;
-          if (isNaN(newVal)) return;
-          setText(newVal.toString());
-        },
+      interact({
+        rules: [
+          // a rule for a number dragger
+          {
+            // the regexp matching the value
+            regexp: /-?\b\d+\.?\d*\b/g,
+            // set cursor to "ew-resize" on hover
+            cursor: "ew-resize",
+            // change number value based on mouse X movement on drag
+            onDrag: (text, setText, e) => {
+              const newVal = Number(text) + e.movementX;
+              if (isNaN(newVal)) return;
+              setText(newVal.toString());
+            },
+          }
+        ],
       }),
     ],
   }),
   parent: document.querySelector('#editor'),
 });
-
-```

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -5,7 +5,7 @@
 import { EditorView } from '@codemirror/view';
 import { EditorState, basicSetup } from '@codemirror/basic-setup';
 import { javascript } from '@codemirror/lang-javascript';
-import { interact, interactRule } from '../src/interact';
+import interact from '../src/interact';
 
 const doc = `
 // hold Alt and drag / click values
@@ -23,72 +23,74 @@ new EditorView({
     extensions: [
       basicSetup,
       javascript(),
-      interact,
-      // number slider
-      interactRule.of({
-        regexp: /-?\b\d+\.?\d*\b/g,
-        cursor: 'ew-resize',
-        onDrag: (text, setText, e) => {
-          // TODO: size aware
-          // TODO: small interval with shift key?
-          const newVal = Number(text) + e.movementX;
-          if (isNaN(newVal)) return;
-          setText(newVal.toString());
-        }
-      }),
-      // bool toggler
-      interactRule.of({
-        regexp: /true|false/g,
-        cursor: 'pointer',
-        onClick: (text, setText) => {
-          switch (text) {
-            case 'true': return setText('false');
-            case 'false': return setText('true');
-          }
-        },
-      }),
-      // vec2 slider
-      interactRule.of({
-        regexp: /vec2\(-?\b\d+\.?\d*\b\s*(,\s*-?\b\d+\.?\d*\b)?\)/g,
-        cursor: 'move',
-        onDrag: (text, setText, e) => {
-          const res = /vec2\((?<x>-?\b\d+\.?\d*\b)\s*(,\s*(?<y>-?\b\d+\.?\d*\b))?\)/.exec(text);
-          let x = Number(res?.groups?.x);
-          let y = Number(res?.groups?.y);
-          if (isNaN(x)) return;
-          if (isNaN(y)) y = x;
-          setText(`vec2(${x + e.movementX}, ${y + e.movementY})`);
-        },
-      }),
-      // color picker
-      interactRule.of({
-        regexp: /rgb\(.*\)/g,
-        cursor: 'pointer',
-        onClick: (text, setText, e) => {
-          const res = /rgb\((?<r>\d+)\s*,\s*(?<g>\d+)\s*,\s*(?<b>\d+)\)/.exec(text);
-          const r = Number(res?.groups?.r);
-          const g = Number(res?.groups?.g);
-          const b = Number(res?.groups?.b);
-          const sel = document.createElement('input');
-          sel.type = 'color';
-          if (!isNaN(r + g + b)) sel.value = rgb2hex(r, g, b);
-          sel.addEventListener('input', (e) => {
-            const el = e.target as HTMLInputElement;
-            if (el.value) {
-              const [r, g, b] = hex2rgb(el.value);
-              setText(`rgb(${r}, ${g}, ${b})`)
+      interact({
+        rules: [
+          {
+            regexp: /-?\b\d+\.?\d*\b/g,
+            cursor: 'ew-resize',
+            onDrag: (text, setText, e) => {
+              // TODO: size aware
+              // TODO: small interval with shift key?
+              const newVal = Number(text) + e.movementX;
+              if (isNaN(newVal)) return;
+              setText(newVal.toString());
             }
-          });
-          sel.click();
-        },
-      }),
-      // url clicker
-      interactRule.of({
-        regexp: /https?:\/\/[^ ']+/g,
-        cursor: 'pointer',
-        onClick: (text) => {
-          window.open(text);
-        },
+          },
+          // bool toggler
+          {
+            regexp: /true|false/g,
+            cursor: 'pointer',
+            onClick: (text, setText) => {
+              switch (text) {
+                case 'true': return setText('false');
+                case 'false': return setText('true');
+              }
+            },
+          },
+          // kaboom vec2 slider
+          {
+            regexp: /vec2\(-?\b\d+\.?\d*\b\s*(,\s*-?\b\d+\.?\d*\b)?\)/g,
+            cursor: "move",
+            onDrag: (text, setText, e) => {
+              const res = /vec2\((?<x>-?\b\d+\.?\d*\b)\s*(,\s*(?<y>-?\b\d+\.?\d*\b))?\)/.exec(text);
+              let x = Number(res?.groups?.x);
+              let y = Number(res?.groups?.y);
+              if (isNaN(x)) return;
+              if (isNaN(y)) y = x;
+              setText(`vec2(${x + e.movementX}, ${y + e.movementY})`);
+            },
+          },
+          // kaboom color picker
+          {
+            regexp: /rgb\(.*\)/g,
+            cursor: "pointer",
+            onClick: (text, setText, e) => {
+              const res = /rgb\((?<r>\d+)\s*,\s*(?<g>\d+)\s*,\s*(?<b>\d+)\)/.exec(text);
+              const r = Number(res?.groups?.r);
+              const g = Number(res?.groups?.g);
+              const b = Number(res?.groups?.b);
+              const sel = document.createElement("input");
+              sel.type = "color";
+              if (!isNaN(r + g + b)) sel.value = rgb2hex(r, g, b);
+              sel.addEventListener("input", (e) => {
+                const el = e.target as HTMLInputElement;
+                if (el.value) {
+                  const [r, g, b] = hex2rgb(el.value);
+                  setText(`rgb(${r}, ${g}, ${b})`)
+                }
+              });
+              sel.click();
+            },
+          },
+          // url clicker
+          {
+            regexp: /https?:\/\/[^ "]+/g,
+            cursor: "pointer",
+            onClick: (text) => {
+              window.open(text);
+            },
+          },
+        ],
       }),
     ],
   }),

--- a/src/interact.ts
+++ b/src/interact.ts
@@ -60,7 +60,7 @@ const interactTheme = EditorView.theme({
  * })
  * ```
  */
-export const interactRule = Facet.define<InteractRule>();
+const interactRule = Facet.define<InteractRule>();
 
 interface ViewState extends PluginValue {
   dragging: Target | null,
@@ -233,7 +233,14 @@ const interactViewPlugin = ViewPlugin.define<ViewState>((view) => ({
   },
 })
 
-export const interact = [
+interface InteractConfig {
+  rules?: InteractRule[],
+}
+
+const interact = (cfg: InteractConfig = {}) => [
   interactTheme,
   interactViewPlugin,
+  (cfg.rules ?? []).map((r) => interactRule.of(r)),
 ];
+
+export default interact;


### PR DESCRIPTION
Discussed in #2, this might be a better pattern

Before:
```js
import { interact, interactRule } from '@replit/codemirror-interact';

extensions: [
  interact,
  interactRule.of({
    regexp: /-?\b\d+\.?\d*\b/g,
    cursor: "ew-resize",
    onDrag: (text, setText, e) => {
      const newVal = Number(text) + e.movementX;
      if (isNaN(newVal)) return;
      setText(newVal.toString());
    },
  }),
]
```

after:
```js
import interact from '@replit/codemirror-interact';

extensions: [
  interact({
    rules: [
      {
        regexp: /-?\b\d+\.?\d*\b/g,
        cursor: "ew-resize",
        onDrag: (text, setText, e) => {
          const newVal = Number(text) + e.movementX;
          if (isNaN(newVal)) return;
          setText(newVal.toString());
        },
      }
    ],
  }),
]
```