### PR TITLE
[WS-501] Introduce className property to rule

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,6 +1,7 @@
 run = "yarn run dev"
 
 entrypoint = "main.sh"
+hidden = [".build", ".config"]
 
 [env]
 XDG_CONFIG_HOME = "/home/runner/.config"
@@ -15,3 +16,14 @@ pattern = "**/{*.ts,*.js,*.tsx,*.jsx}"
 
 [languages.typescript.languageServer]
 start = "typescript-language-server --stdio"
+
+[packager]
+language = "nodejs"
+
+[packager.features]
+enabledForHosting = false
+packageSearch = true
+guessImports = true
+
+[gitHubImport]
+requiredFiles = [".replit", "replit.nix", ".config"]

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -17,12 +17,19 @@ const e = false
 const f = 'http://example.com'
 `.trim();
 
+const theme = EditorView.theme({
+  '.cm-interact-url > *': {
+    textDecoration: 'underline'
+  }
+})
+
 new EditorView({
   state: EditorState.create({
     doc,
     extensions: [
       basicSetup,
       javascript(),
+      theme,
       interact({
         rules: [
           {
@@ -86,6 +93,7 @@ new EditorView({
           {
             regexp: /https?:\/\/[^ "]+/g,
             cursor: "pointer",
+            className: "cm-interact-url",
             onClick: (text) => {
               window.open(text);
             },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/codemirror-interact",
   "description": "Interact with custom values",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "license": "MIT",
   "author": {
     "name": "tga",
@@ -35,5 +35,8 @@
     "@codemirror/view": "^6.0.0",
     "codemirror": "^6.0.0",
     "vite": "^3.0.0"
+  },
+  "dependencies": {
+    "@codemirror/state": "^6.2.1"
   }
 }

--- a/src/interact.ts
+++ b/src/interact.ts
@@ -23,6 +23,7 @@ export interface InteractRule {
   regexp: RegExp,
   cursor?: string,
   style?: any,
+  className?: string,
   onClick?: (text: string, setText: (t: string) => void, e: MouseEvent) => void,
   onDrag?: (text: string, setText: (t: string) => void, e: MouseEvent) => void,
 }
@@ -68,8 +69,9 @@ const interactField = StateField.define<Target | null>({
 
       const from = target.pos;
       const to = target.pos + target.text.length;
+      const className = target.rule.className;
 
-      return Decoration.set(mark.range(from, to))
+      return Decoration.set(mark({ className }).range(from, to))
     }),
     EditorView.contentAttributes.from(field, (target) => {
       if (!target || !target.rule.cursor) {
@@ -83,7 +85,10 @@ const interactField = StateField.define<Target | null>({
 
 const setInteract = StateEffect.define<Target | null>();
 
-const mark = Decoration.mark({ class: 'cm-interact' });
+const mark = (e: { className?: string }) => Decoration.mark({
+  class: `cm-interact ${e?.className ?? ''}`
+});
+
 
 const interactTheme = EditorView.theme({
   '.cm-interact': {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,66 @@
+{
+	"compilerOptions": {
+		/* Visit https://aka.ms/tsconfig.json to read more about this file */
+		/* Basic Options */
+		// "incremental": true,                         /* Enable incremental compilation */
+		"target": "ESNEXT", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */
+		"module": "ESNext", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+		// "lib": [],                                   /* Specify library files to be included in the compilation. */
+		// "allowJs": true,                             /* Allow javascript files to be compiled. */
+		// "checkJs": true,                             /* Report errors in .js files. */
+		// "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
+		// "declaration": true,                         /* Generates corresponding '.d.ts' file. */
+		// "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
+		// "sourceMap": true,                           /* Generates corresponding '.map' file. */
+		// "outFile": "./",                             /* Concatenate and emit output to single file. */
+		// "outDir": "./",                              /* Redirect output structure to the directory. */
+		// "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+		// "composite": true,                           /* Enable project compilation */
+		// "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
+		// "removeComments": true,                      /* Do not emit comments to output. */
+		"noEmit": true,                              /* Do not emit outputs. */
+		// "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
+		// "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+		// "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+		/* Strict Type-Checking Options */
+		"strict": true, /* Enable all strict type-checking options. */
+		// "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+		// "strictNullChecks": true,                    /* Enable strict null checks. */
+		// "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
+		// "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+		// "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
+		// "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
+		// "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
+		/* Additional Checks */
+		// "noUnusedLocals": true,                      /* Report errors on unused locals. */
+		// "noUnusedParameters": true,                  /* Report errors on unused parameters. */
+		// "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
+		// "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
+		// "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
+		// "noImplicitOverride": true,                  /* Ensure overriding members in derived classes are marked with an 'override' modifier. */
+		// "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
+		/* Module Resolution Options */
+		"moduleResolution": "node", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+		// "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
+		// "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+		// "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
+		"typeRoots": [
+			"./node_modules/@types",
+		], /* List of folders to include type definitions from. */
+		// "types": [],                                 /* Type declaration files to be included in compilation. */
+		// "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+		"esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+		// "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
+		// "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
+		/* Experimental Options */
+		// "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */
+		// "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
+		/* Advanced Options */
+		"skipLibCheck": true, /* Skip type checking of declaration files. */
+		"forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+	},
+	"exclude": [
+		"node_modules",
+		".build"
+	]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,17 +104,17 @@
     "@codemirror/view" "^6.0.0"
     crelt "^1.0.5"
 
-"@codemirror/state@^6.0.0":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.1.1.tgz#4f512e5e34ea23a5e10b2c1fe43f6195e90417bb"
-  integrity sha512-2s+aXsxmAwnR3Rd+JDHPG/1lw0YsA9PEwl7Re88gHJHGfxyfEzKBmsN4rr53RyPIR4lzbbhJX0DCq0WlqlBIRw==
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.1.4", "@codemirror/state@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.2.1.tgz#6dc8d8e5abb26b875e3164191872d69a5e85bd73"
+  integrity sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw==
 
 "@codemirror/view@^6.0.0":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.2.1.tgz#299698639c658c738f10021c5ea78a513c63977b"
-  integrity sha512-r1svbtAj2Lp/86F3yy1TfDAOAtJRGLINLSEqByETyUaGo1EnLS+P+bbGCVHV62z46BzZYm16noDid69+4bzn0g==
+  version "6.14.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.14.1.tgz#22cbc9b95887c996d1e886e6a85a8bb353cacce6"
+  integrity sha512-ofcsI7lRFo4N0rfnd+V3Gh2boQU3DmaaSKhDOvXUWjeOeuupMXer2e/3i9TUFN7aEIntv300EFBWPEiYVm2svg==
   dependencies:
-    "@codemirror/state" "^6.0.0"
+    "@codemirror/state" "^6.1.4"
     style-mod "^4.0.0"
     w3c-keyname "^2.2.4"
 
@@ -1133,9 +1133,9 @@ strip-json-comments@3.1.1:
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 style-mod@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.0.0.tgz#97e7c2d68b592975f2ca7a63d0dd6fcacfe35a01"
-  integrity sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.0.3.tgz#136c4abc905f82a866a18b39df4dc08ec762b1ad"
+  integrity sha512-78Jv8kYJdjbvRwwijtCevYADfsI0lGzYJe4mMFdceO8l75DFFDoqBhR1jVDicDRRaX4//g1u9wKeo+ztc2h1Rw==
 
 supports-color@8.1.1:
   version "8.1.1"
@@ -1205,9 +1205,9 @@ vite@^3.0.0:
     fsevents "~2.3.2"
 
 w3c-keyname@^2.2.4:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.6.tgz#8412046116bc16c5d73d4e612053ea10a189c85f"
-  integrity sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz#7b17c8c6883d4e8b86ac8aba79d39e880f8869c5"
+  integrity sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
 
 workerpool@6.2.1:
   version "6.2.1"


### PR DESCRIPTION
# Why

<!--
 - Describe what prompted you to make the change
 - It should be a good historical record of the motivations and context of the PR
-->

I want to add some more decoration to a URL range - specifically text-decoration.

The best way to do this seems to be to allow the user to specify a className, that we'll apply to the mark decoration.

https://linear.app/replit/issue/WS-501/linkify-urls-in-editor

# What changed

* Introduce a `className` property on the rule, then apply it.
* A few other misc changes to get it running on replit/part of github import


<!--
 - Describe what changed to a level of detail that someone with little context with your PR could be able to review it.
 - People from the future should also be able to read this and understand what's going on.
 - Annotate changes with a self-review where necessary.
 - Post a screenshot or video when relevant
-->

# Test plan

In the dev environment I now see an underline applied by my theme:

https://github.com/replit/codemirror-interact/assets/16962017/e23f8672-1818-4eb8-a8b1-e23530f884b1




<!-- 
 - Test plans should allow people without context to run through a list of steps and assert behavior.
 - If this is a bug fix, the test plan should include steps to reproduce the problem.
 - If this is a feature, the test plan should reflect a human-readable end-to-end test.
-->
